### PR TITLE
fix: Non-portable use of internal namespace std::chrono::_V2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,4 +20,4 @@ add_executable(${PROJECT_NAME} ${SOURCES})
 
 include_directories(${INCLUDES})
 
-target_link_libraries(Local-MIP pthread -lpthread -lquadmath z -lz boost_thread boost_date_time boost_system)
+target_link_libraries(Local-MIP pthread z)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,4 +20,4 @@ add_executable(${PROJECT_NAME} ${SOURCES})
 
 include_directories(${INCLUDES})
 
-target_link_libraries(Local-MIP pthread z)
+target_link_libraries(Local-MIP pthread -lpthread -lquadmath z -lz boost_thread boost_date_time boost_system)

--- a/code/LocalSearch/LocalMIP.cpp
+++ b/code/LocalSearch/LocalMIP.cpp
@@ -18,7 +18,7 @@
 
 int LocalMIP::LocalSearch(
     Value _optimalObj,
-    chrono::_V2::system_clock::time_point _clkStart)
+    chrono::system_clock::time_point _clkStart)
 {
   Allocate();
   InitSolution();
@@ -62,9 +62,9 @@ int LocalMIP::LocalSearch(
 }
 
 bool LocalMIP::Timeout(
-    chrono::_V2::system_clock::time_point &_clkStart)
+    chrono::system_clock::time_point &_clkStart)
 {
-  auto clk_now = chrono::high_resolution_clock::now();
+  auto clk_now = chrono::system_clock::now();
   auto solve_time =
       chrono::duration_cast<chrono::seconds>(clk_now - _clkStart).count();
   if (solve_time >= OPT(cutoff))
@@ -73,7 +73,7 @@ bool LocalMIP::Timeout(
 }
 
 void LocalMIP::LogObj(
-    chrono::_V2::system_clock::time_point &_clkStart)
+    chrono::system_clock::time_point &_clkStart)
 {
   auto clk = TimeNow();
   printf(

--- a/code/LocalSearch/LocalMIP.cpp
+++ b/code/LocalSearch/LocalMIP.cpp
@@ -18,7 +18,7 @@
 
 int LocalMIP::LocalSearch(
     Value _optimalObj,
-    chrono::system_clock::time_point _clkStart)
+    chrono::high_resolution_clock::time_point _clkStart)
 {
   Allocate();
   InitSolution();
@@ -62,9 +62,9 @@ int LocalMIP::LocalSearch(
 }
 
 bool LocalMIP::Timeout(
-    chrono::system_clock::time_point &_clkStart)
+    chrono::high_resolution_clock::time_point &_clkStart)
 {
-  auto clk_now = chrono::system_clock::now();
+  auto clk_now = chrono::high_resolution_clock::now();
   auto solve_time =
       chrono::duration_cast<chrono::seconds>(clk_now - _clkStart).count();
   if (solve_time >= OPT(cutoff))
@@ -73,7 +73,7 @@ bool LocalMIP::Timeout(
 }
 
 void LocalMIP::LogObj(
-    chrono::system_clock::time_point &_clkStart)
+    chrono::high_resolution_clock::time_point &_clkStart)
 {
   auto clk = TimeNow();
   printf(

--- a/code/LocalSearch/LocalMIP.h
+++ b/code/LocalSearch/LocalMIP.h
@@ -87,9 +87,9 @@ private:
       Value &_res);
   void InitSolution();
   bool Timeout(
-      chrono::_V2::system_clock::time_point &_clkStart);
+      chrono::system_clock::time_point &_clkStart);
   void LogObj(
-      chrono::_V2::system_clock::time_point &_clkStart);
+      chrono::system_clock::time_point &_clkStart);
 
 public:
   LocalMIP(
@@ -98,7 +98,7 @@ public:
   ~LocalMIP();
   int LocalSearch(
       Value _optimalObj,
-      chrono::_V2::system_clock::time_point _clkStart);
+      chrono::system_clock::time_point _clkStart);
   void PrintResult();
   void PrintSol();
   void Allocate();

--- a/code/LocalSearch/LocalMIP.h
+++ b/code/LocalSearch/LocalMIP.h
@@ -87,9 +87,9 @@ private:
       Value &_res);
   void InitSolution();
   bool Timeout(
-      chrono::system_clock::time_point &_clkStart);
+      chrono::high_resolution_clock::time_point &_clkStart);
   void LogObj(
-      chrono::system_clock::time_point &_clkStart);
+      chrono::high_resolution_clock::time_point &_clkStart);
 
 public:
   LocalMIP(
@@ -98,7 +98,7 @@ public:
   ~LocalMIP();
   int LocalSearch(
       Value _optimalObj,
-      chrono::system_clock::time_point _clkStart);
+      chrono::high_resolution_clock::time_point _clkStart);
   void PrintResult();
   void PrintSol();
   void Allocate();

--- a/code/Solver.h
+++ b/code/Solver.h
@@ -33,8 +33,8 @@ public:
   ModelConUtil *modelConUtil;
   ModelVarUtil *modelVarUtil;
   LocalMIP *localMIP;
-  chrono::_V2::system_clock::time_point clkStart =
-      chrono::high_resolution_clock::now();
+  chrono::system_clock::time_point clkStart =
+      chrono::system_clock::now();
   Solver();
   ~Solver();
   void Run();

--- a/code/Solver.h
+++ b/code/Solver.h
@@ -33,8 +33,8 @@ public:
   ModelConUtil *modelConUtil;
   ModelVarUtil *modelVarUtil;
   LocalMIP *localMIP;
-  chrono::system_clock::time_point clkStart =
-      chrono::system_clock::now();
+  chrono::high_resolution_clock::time_point clkStart =
+      chrono::high_resolution_clock::now();
   Solver();
   ~Solver();
   void Run();

--- a/code/utils/header.h
+++ b/code/utils/header.h
@@ -49,10 +49,10 @@ enum class VarType
     Real,
     Fixed
 };
-std::chrono::_V2::system_clock::time_point TimeNow();
+std::chrono::system_clock::time_point TimeNow();
 double ElapsedTime(
-    const std::chrono::_V2::system_clock::time_point &a,
-    const std::chrono::_V2::system_clock::time_point &b);
+    const std::chrono::system_clock::time_point &a,
+    const std::chrono::system_clock::time_point &b);
 bool IsBlank(
     const string &a);
 void PrintfError(

--- a/code/utils/header.h
+++ b/code/utils/header.h
@@ -49,10 +49,10 @@ enum class VarType
     Real,
     Fixed
 };
-std::chrono::system_clock::time_point TimeNow();
+std::chrono::high_resolution_clock::time_point TimeNow();
 double ElapsedTime(
-    const std::chrono::system_clock::time_point &a,
-    const std::chrono::system_clock::time_point &b);
+    const std::chrono::high_resolution_clock::time_point &a,
+    const std::chrono::high_resolution_clock::time_point &b);
 bool IsBlank(
     const string &a);
 void PrintfError(

--- a/code/utils/utils.cpp
+++ b/code/utils/utils.cpp
@@ -16,14 +16,14 @@
 
 #include "header.h"
 
-std::chrono::_V2::system_clock::time_point TimeNow()
+std::chrono::system_clock::time_point TimeNow()
 {
-  return chrono::high_resolution_clock::now();
+  return chrono::system_clock::now();
 }
 
 double ElapsedTime(
-    const std::chrono::_V2::system_clock::time_point &a,
-    const std::chrono::_V2::system_clock::time_point &b)
+    const std::chrono::system_clock::time_point &a,
+    const std::chrono::system_clock::time_point &b)
 {
   return chrono::duration_cast<chrono::milliseconds>(a - b).count() / 1000.0;
 }

--- a/code/utils/utils.cpp
+++ b/code/utils/utils.cpp
@@ -16,14 +16,14 @@
 
 #include "header.h"
 
-std::chrono::system_clock::time_point TimeNow()
+std::chrono::high_resolution_clock::time_point TimeNow()
 {
-  return chrono::system_clock::now();
+  return chrono::high_resolution_clock::now();
 }
 
 double ElapsedTime(
-    const std::chrono::system_clock::time_point &a,
-    const std::chrono::system_clock::time_point &b)
+    const std::chrono::high_resolution_clock::time_point &a,
+    const std::chrono::high_resolution_clock::time_point &b)
 {
   return chrono::duration_cast<chrono::milliseconds>(a - b).count() / 1000.0;
 }


### PR DESCRIPTION
see #4 

Tested in:
- clang version 20.1.8, arm64-apple-darwin23.6.0
- g++ 11.4.0, amd64 ubuntu 22.04