### PR TITLE
Prepare Local-MIP callback for cuLocalMIP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 find_package(Threads REQUIRED)
 
+option(LOCALMIP_BUILD_CLI "Build the Local-MIP command line solver" ON)
+option(LOCALMIP_BUILD_TESTS "Build Local-MIP tests" ON)
+
 file(GLOB_RECURSE LIB_SOURCES CONFIGURE_DEPENDS "src/*.cpp" "src/*.cc")
 list(REMOVE_ITEM LIB_SOURCES "${PROJECT_SOURCE_DIR}/src/utils/main.cpp")
 
@@ -36,8 +39,12 @@ target_link_libraries(LocalMIP PUBLIC
   Threads::Threads
 )
 
-add_executable(${PROJECT_NAME} src/utils/main.cpp)
-target_link_libraries(${PROJECT_NAME} PRIVATE LocalMIP::core)
+if(LOCALMIP_BUILD_CLI)
+  add_executable(${PROJECT_NAME} src/utils/main.cpp)
+  target_link_libraries(${PROJECT_NAME} PRIVATE LocalMIP::core)
+endif()
 
-enable_testing()
-add_subdirectory(tests)
+if(LOCALMIP_BUILD_TESTS)
+  enable_testing()
+  add_subdirectory(tests)
+endif()

--- a/src/local_mip/Local_MIP.cpp
+++ b/src/local_mip/Local_MIP.cpp
@@ -531,7 +531,7 @@ const Model_Manager* Local_MIP::get_model_manager() const
 }
 
 void Local_MIP::set_on_improvement_callback(
-    std::function<void(const double*, size_t, double)> p_cbk)
+    Improvement_Cbk p_cbk)
 {
   m_local_search->set_on_improvement_callback(std::move(p_cbk));
 }
@@ -555,15 +555,21 @@ void Local_MIP::set_exchange_check_interval(size_t p_interval)
   m_local_search->set_exchange_check_interval(p_interval);
 }
 
-void Local_MIP::set_exchange_check_callback(std::function<void()> p_cbk)
+void Local_MIP::set_exchange_check_callback(Exchange_Check_Cbk p_cbk)
 {
   m_local_search->set_exchange_check_callback(std::move(p_cbk));
 }
 
 void Local_MIP::set_on_infeas_improvement_callback(
-    std::function<void(const double*, size_t, size_t)> p_cbk)
+    Infeas_Improvement_Cbk p_cbk)
 {
   m_local_search->set_on_infeas_improvement_callback(std::move(p_cbk));
+}
+
+bool Local_MIP::inject_infeas_bound(size_t p_var_num,
+                                    size_t p_unsat_num)
+{
+  return m_local_search->inject_infeas_bound(p_var_num, p_unsat_num);
 }
 
 bool Local_MIP::inject_infeas_solution(const double* p_sol,

--- a/src/local_mip/Local_MIP.cpp
+++ b/src/local_mip/Local_MIP.cpp
@@ -48,7 +48,7 @@ Local_MIP::Local_MIP()
       m_model_manager(std::make_unique<Model_Manager>()),
       m_local_search(
           std::make_unique<Local_Search>(m_model_manager.get())),
-      m_model_api(nullptr), m_use_model_api(false)
+      m_model_api(nullptr), m_use_model_api(false), m_model_loaded(false)
 {
 }
 
@@ -377,16 +377,22 @@ void Local_MIP::set_break_eq_feas(bool p_enable)
          p_enable ? "true" : "false");
 }
 
+void Local_MIP::load_model()
+{
+  if (m_model_loaded)
+    return;
+  prepare_reader();
+  m_reader->read(m_model_file.c_str());
+  m_model_loaded = true;
+}
+
 void Local_MIP::run()
 {
   printf("c welcome to Local-MIP solver\n");
   if (m_use_model_api)
     m_model_api->build_model(*m_model_manager);
-  else
-  {
-    prepare_reader();
-    m_reader->read(m_model_file.c_str());
-  }
+  else if (!m_model_loaded)
+    load_model();
 
   if (!m_model_manager->process_after_read())
   {
@@ -522,6 +528,50 @@ const std::vector<double>& Local_MIP::get_solution() const
 const Model_Manager* Local_MIP::get_model_manager() const
 {
   return m_model_manager.get();
+}
+
+void Local_MIP::set_on_improvement_callback(
+    std::function<void(const double*, size_t, double)> p_cbk)
+{
+  m_local_search->set_on_improvement_callback(std::move(p_cbk));
+}
+
+bool Local_MIP::inject_solution(const double* p_sol,
+                                size_t p_var_num,
+                                double p_obj)
+{
+  return m_local_search->inject_solution(p_sol, p_var_num, p_obj);
+}
+
+bool Local_MIP::inject_to_current_and_restart(
+    const double* p_sol, size_t p_var_num, size_t p_restart_step_override)
+{
+  return m_local_search->inject_to_current_and_restart(
+      p_sol, p_var_num, p_restart_step_override);
+}
+
+void Local_MIP::set_exchange_check_interval(size_t p_interval)
+{
+  m_local_search->set_exchange_check_interval(p_interval);
+}
+
+void Local_MIP::set_exchange_check_callback(std::function<void()> p_cbk)
+{
+  m_local_search->set_exchange_check_callback(std::move(p_cbk));
+}
+
+void Local_MIP::set_on_infeas_improvement_callback(
+    std::function<void(const double*, size_t, size_t)> p_cbk)
+{
+  m_local_search->set_on_infeas_improvement_callback(std::move(p_cbk));
+}
+
+bool Local_MIP::inject_infeas_solution(const double* p_sol,
+                                       size_t p_var_num,
+                                       size_t p_unsat_num)
+{
+  return m_local_search->inject_infeas_solution(
+      p_sol, p_var_num, p_unsat_num);
 }
 
 bool Local_MIP::check_model_api() const

--- a/src/local_mip/Local_MIP.h
+++ b/src/local_mip/Local_MIP.h
@@ -21,6 +21,7 @@
 #include <condition_variable>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -59,6 +60,8 @@ private:
   std::unique_ptr<Model_API> m_model_api;
 
   bool m_use_model_api;
+
+  bool m_model_loaded;
 
   void request_timeout_stop();
 
@@ -200,6 +203,8 @@ public:
 
   bool set_integrality(const std::string& p_name, Var_Type p_type);
 
+  void load_model();
+
   void run();
 
   double get_obj_value() const;
@@ -209,4 +214,24 @@ public:
   const std::vector<double>& get_solution() const;
 
   const Model_Manager* get_model_manager() const;
+
+  void set_on_improvement_callback(
+      std::function<void(const double*, size_t, double)> p_cbk);
+
+  bool inject_solution(const double* p_sol, size_t p_var_num, double p_obj);
+
+  bool inject_to_current_and_restart(const double* p_sol,
+                                     size_t p_var_num,
+                                     size_t p_restart_step_override);
+
+  void set_exchange_check_interval(size_t p_interval);
+
+  void set_exchange_check_callback(std::function<void()> p_cbk);
+
+  void set_on_infeas_improvement_callback(
+      std::function<void(const double*, size_t, size_t)> p_cbk);
+
+  bool inject_infeas_solution(const double* p_sol,
+                              size_t p_var_num,
+                              size_t p_unsat_num);
 };

--- a/src/local_mip/Local_MIP.h
+++ b/src/local_mip/Local_MIP.h
@@ -215,22 +215,51 @@ public:
 
   const Model_Manager* get_model_manager() const;
 
-  void set_on_improvement_callback(
-      std::function<void(const double*, size_t, double)> p_cbk);
+  using Improvement_Cbk =
+      std::function<void(const double* p_sol, size_t p_var_num, double p_obj)>;
 
+  using Exchange_Check_Cbk = std::function<void()>;
+
+  using Infeas_Improvement_Cbk = std::function<void(
+      const double* p_sol, size_t p_var_num, size_t p_unsat_num)>;
+
+  // Called from the search thread when a new feasible incumbent is accepted.
+  // p_sol is valid only for the duration of the callback; copy it if it must
+  // outlive the call. p_obj is reported in user objective sense.
+  void set_on_improvement_callback(Improvement_Cbk p_cbk);
+
+  // Inject an externally found feasible incumbent. The solution must match the
+  // model variable order and satisfy bounds, integrality, and constraints.
+  // Returns false for invalid, infeasible, or non-improving incumbents.
   bool inject_solution(const double* p_sol, size_t p_var_num, double p_obj);
 
+  // Replace the current search point and reset local-search state. This API is
+  // intended to be called from the search thread, typically inside the exchange
+  // callback. The injected point may be infeasible but must satisfy variable
+  // bounds and integrality.
   bool inject_to_current_and_restart(const double* p_sol,
                                      size_t p_var_num,
                                      size_t p_restart_step_override);
 
+  // Set how often the search loop invokes the exchange callback. A zero
+  // interval disables periodic checks.
   void set_exchange_check_interval(size_t p_interval);
 
-  void set_exchange_check_callback(std::function<void()> p_cbk);
+  // Called from the search thread every p_interval search steps. The callback
+  // may call injection APIs directly; it must not mutate Local_MIP from a
+  // separate thread unless external synchronization is provided.
+  void set_exchange_check_callback(Exchange_Check_Cbk p_cbk);
 
-  void set_on_infeas_improvement_callback(
-      std::function<void(const double*, size_t, size_t)> p_cbk);
+  // Called before the first feasible solution whenever the current solution
+  // improves the best known number of unsatisfied constraints.
+  void set_on_infeas_improvement_callback(Infeas_Improvement_Cbk p_cbk);
 
+  // Update the best known infeasible progress without changing the current
+  // search point.
+  bool inject_infeas_bound(size_t p_var_num, size_t p_unsat_num);
+
+  // Optionally inject an infeasible current point together with a better unsat
+  // count. If p_sol is nullptr, this is equivalent to inject_infeas_bound().
   bool inject_infeas_solution(const double* p_sol,
                               size_t p_var_num,
                               size_t p_unsat_num);

--- a/src/local_search/Local_Search.cpp
+++ b/src/local_search/Local_Search.cpp
@@ -291,6 +291,52 @@ bool Local_Search::verify_solution() const
   return true;
 }
 
+bool Local_Search::solution_values_valid(const double* p_sol,
+                                         size_t p_var_num) const
+{
+  if (p_sol == nullptr || p_var_num != m_var_num)
+    return false;
+  for (size_t var_idx = 0; var_idx < m_var_num; ++var_idx)
+  {
+    const auto& model_var = m_model_manager->var(var_idx);
+    double value = p_sol[var_idx];
+    if (!std::isfinite(value) || !model_var.in_bound(value))
+      return false;
+    if (!model_var.is_real() &&
+        std::fabs(value - std::round(value)) > k_feas_tolerance)
+      return false;
+  }
+  return true;
+}
+
+bool Local_Search::solution_feasible(const double* p_sol,
+                                     size_t p_var_num) const
+{
+  if (!solution_values_valid(p_sol, p_var_num))
+    return false;
+  if (m_con_num == 0 || m_con_constant.size() < m_con_num ||
+      m_con_is_equality.size() < m_con_num)
+    return false;
+  for (size_t con_idx = 1; con_idx < m_con_num; ++con_idx)
+  {
+    const auto& model_con = m_model_manager->con(con_idx);
+    long double activity = 0.0L;
+    for (size_t term_idx = 0; term_idx < model_con.term_num(); ++term_idx)
+      activity += static_cast<long double>(model_con.coeff(term_idx)) *
+                  static_cast<long double>(
+                      p_sol[model_con.var_idx(term_idx)]);
+    double gap = static_cast<double>(activity) - m_con_constant[con_idx];
+    if (m_con_is_equality[con_idx])
+    {
+      if (std::fabs(gap) > k_feas_tolerance)
+        return false;
+    }
+    else if (gap > k_feas_tolerance)
+      return false;
+  }
+  return true;
+}
+
 void Local_Search::write_sol() const
 {
   printf("c best-found solution is written to %s\n", m_sol_path.c_str());
@@ -687,7 +733,7 @@ void Local_Search::set_break_eq_feas(bool p_enable)
 }
 
 void Local_Search::set_on_improvement_callback(
-    std::function<void(const double*, size_t, double)> p_cbk)
+    Improvement_Cbk p_cbk)
 {
   m_on_improvement_cbk = std::move(p_cbk);
 }
@@ -696,7 +742,7 @@ bool Local_Search::inject_solution(const double* p_sol,
                                    size_t p_var_num,
                                    double p_obj)
 {
-  if (p_sol == nullptr || p_var_num != m_var_num)
+  if (!solution_feasible(p_sol, p_var_num))
     return false;
 
   double internal_obj =
@@ -719,7 +765,7 @@ bool Local_Search::inject_solution(const double* p_sol,
 bool Local_Search::inject_to_current_and_restart(
     const double* p_sol, size_t p_var_num, size_t p_restart_step_override)
 {
-  if (p_sol == nullptr || p_var_num != m_var_num)
+  if (!solution_values_valid(p_sol, p_var_num))
     return false;
 
   memcpy(m_var_current_value.data(), p_sol, m_var_num * sizeof(double));
@@ -736,25 +782,40 @@ void Local_Search::set_exchange_check_interval(size_t p_interval)
   m_exchange_check_interval = p_interval;
 }
 
-void Local_Search::set_exchange_check_callback(std::function<void()> p_cbk)
+void Local_Search::set_exchange_check_callback(Exchange_Check_Cbk p_cbk)
 {
   m_exchange_check_cbk = std::move(p_cbk);
 }
 
 void Local_Search::set_on_infeas_improvement_callback(
-    std::function<void(const double*, size_t, size_t)> p_cbk)
+    Infeas_Improvement_Cbk p_cbk)
 {
   m_on_infeas_improvement_cbk = std::move(p_cbk);
 }
 
-bool Local_Search::inject_infeas_solution(const double*,
-                                          size_t p_var_num,
-                                          size_t p_unsat_num)
+bool Local_Search::inject_infeas_bound(size_t p_var_num,
+                                       size_t p_unsat_num)
 {
   if (m_is_found_feasible || p_var_num != m_var_num ||
       p_unsat_num >= m_min_unsat_con)
     return false;
   m_min_unsat_con = p_unsat_num;
+  return true;
+}
+
+bool Local_Search::inject_infeas_solution(const double* p_sol,
+                                          size_t p_var_num,
+                                          size_t p_unsat_num)
+{
+  if (p_sol != nullptr && !solution_values_valid(p_sol, p_var_num))
+    return false;
+  if (!inject_infeas_bound(p_var_num, p_unsat_num))
+    return false;
+  if (p_sol != nullptr)
+  {
+    memcpy(m_var_current_value.data(), p_sol, m_var_num * sizeof(double));
+    reset_after_restart();
+  }
   return true;
 }
 

--- a/src/local_search/Local_Search.cpp
+++ b/src/local_search/Local_Search.cpp
@@ -39,6 +39,10 @@ int Local_Search::run_search()
   init_state();
   while (!m_terminated)
   {
+    if (m_exchange_check_cbk && m_exchange_check_interval > 0 &&
+        m_cur_step % m_exchange_check_interval == 0)
+      m_exchange_check_cbk();
+
     if (m_restart.execute(m_restart_ctx))
       reset_after_restart();
     if (m_con_unsat_idxs.empty())
@@ -216,7 +220,12 @@ void Local_Search::apply_move(size_t p_var_idx, double p_delta)
   }
   m_current_obj_breakthrough = m_con_activity[0] <= m_con_constant[0];
   if (m_con_unsat_idxs.size() < m_min_unsat_con)
+  {
     m_min_unsat_con = m_con_unsat_idxs.size();
+    if (!m_is_found_feasible && m_on_infeas_improvement_cbk)
+      m_on_infeas_improvement_cbk(
+          m_var_current_value.data(), m_var_num, m_min_unsat_con);
+  }
   assert(model_var.in_bound(m_var_current_value[p_var_idx]));
 }
 
@@ -443,6 +452,8 @@ Local_Search::Local_Search(const Model_Manager* p_model_manager)
       m_bms_random_op(250), m_best_obj(k_inf),
       m_logged_obj_value(std::numeric_limits<double>::quiet_NaN()),
       m_terminated(false), m_sol_path(""), m_min_unsat_con(SIZE_MAX),
+      m_exchange_check_interval(0), m_on_improvement_cbk(nullptr),
+      m_exchange_check_cbk(nullptr), m_on_infeas_improvement_cbk(nullptr),
       m_has_objective(false), m_is_unbounded(false),
       m_readonly_ctx(*m_model_manager,
                      m_var_current_value,
@@ -673,4 +684,81 @@ void Local_Search::set_tabu_variation(size_t p_value)
 void Local_Search::set_break_eq_feas(bool p_enable)
 {
   m_break_eq_feas = p_enable;
+}
+
+void Local_Search::set_on_improvement_callback(
+    std::function<void(const double*, size_t, double)> p_cbk)
+{
+  m_on_improvement_cbk = std::move(p_cbk);
+}
+
+bool Local_Search::inject_solution(const double* p_sol,
+                                   size_t p_var_num,
+                                   double p_obj)
+{
+  if (p_sol == nullptr || p_var_num != m_var_num)
+    return false;
+
+  double internal_obj =
+      p_obj / m_model_manager->is_min() - m_model_manager->obj_offset();
+  if (internal_obj >= m_best_obj)
+    return false;
+
+  memcpy(m_var_best_value.data(), p_sol, m_var_num * sizeof(double));
+  m_best_obj = internal_obj;
+  m_con_constant[0] = m_best_obj - k_opt_tolerance;
+  m_last_improve_step = m_cur_step;
+  m_is_found_feasible = true;
+  publish_best_obj();
+  printf("c [%10.2lf] local search injected external solution obj=%.15g\n",
+         elapsed_time(),
+         p_obj);
+  return true;
+}
+
+bool Local_Search::inject_to_current_and_restart(
+    const double* p_sol, size_t p_var_num, size_t p_restart_step_override)
+{
+  if (p_sol == nullptr || p_var_num != m_var_num)
+    return false;
+
+  memcpy(m_var_current_value.data(), p_sol, m_var_num * sizeof(double));
+  reset_after_restart();
+  m_restart.set_restart_step(p_restart_step_override);
+  printf("c [%10.2lf] local search injected current solution, restart_step=%zu\n",
+         elapsed_time(),
+         p_restart_step_override);
+  return true;
+}
+
+void Local_Search::set_exchange_check_interval(size_t p_interval)
+{
+  m_exchange_check_interval = p_interval;
+}
+
+void Local_Search::set_exchange_check_callback(std::function<void()> p_cbk)
+{
+  m_exchange_check_cbk = std::move(p_cbk);
+}
+
+void Local_Search::set_on_infeas_improvement_callback(
+    std::function<void(const double*, size_t, size_t)> p_cbk)
+{
+  m_on_infeas_improvement_cbk = std::move(p_cbk);
+}
+
+bool Local_Search::inject_infeas_solution(const double*,
+                                          size_t p_var_num,
+                                          size_t p_unsat_num)
+{
+  if (m_is_found_feasible || p_var_num != m_var_num ||
+      p_unsat_num >= m_min_unsat_con)
+    return false;
+  m_min_unsat_con = p_unsat_num;
+  return true;
+}
+
+size_t Local_Search::get_min_unsat_con() const
+{
+  return m_min_unsat_con;
 }

--- a/src/local_search/Local_Search.h
+++ b/src/local_search/Local_Search.h
@@ -219,6 +219,10 @@ private:
 
   bool verify_solution() const;
 
+  bool solution_values_valid(const double* p_sol, size_t p_var_num) const;
+
+  bool solution_feasible(const double* p_sol, size_t p_var_num) const;
+
   bool solve_objective_only();
 
   void init_state();
@@ -249,6 +253,14 @@ public:
   using Neighbor_Scoring_Cbk = Scoring::Neighbor_Cbk;
 
   using Neighbor_Cbk = Neighbor::Neighbor_Cbk;
+
+  using Improvement_Cbk =
+      std::function<void(const double* p_sol, size_t p_var_num, double p_obj)>;
+
+  using Exchange_Check_Cbk = std::function<void()>;
+
+  using Infeas_Improvement_Cbk = std::function<void(
+      const double* p_sol, size_t p_var_num, size_t p_unsat_num)>;
 
   Local_Search(const Model_Manager* p_model_manager);
 
@@ -334,22 +346,43 @@ public:
 
   void set_break_eq_feas(bool p_break_eq_feas);
 
-  void set_on_improvement_callback(
-      std::function<void(const double*, size_t, double)> p_cbk);
+  // Called from the search thread when a new feasible incumbent is accepted.
+  // p_sol is valid only for the duration of the callback; copy it if it must
+  // outlive the call. p_obj is reported in user objective sense.
+  void set_on_improvement_callback(Improvement_Cbk p_cbk);
 
+  // Inject an externally found feasible incumbent. The solution must match the
+  // model variable order and satisfy bounds, integrality, and constraints.
+  // Returns false for invalid, infeasible, or non-improving incumbents.
   bool inject_solution(const double* p_sol, size_t p_var_num, double p_obj);
 
+  // Replace the current search point and reset local-search state. This API is
+  // intended to be called from the search thread, typically inside the exchange
+  // callback. The injected point may be infeasible but must satisfy variable
+  // bounds and integrality.
   bool inject_to_current_and_restart(const double* p_sol,
                                      size_t p_var_num,
                                      size_t p_restart_step_override);
 
+  // Set how often the search loop invokes the exchange callback. A zero
+  // interval disables periodic checks.
   void set_exchange_check_interval(size_t p_interval);
 
-  void set_exchange_check_callback(std::function<void()> p_cbk);
+  // Called from the search thread every p_interval search steps. The callback
+  // may call injection APIs directly; it must not mutate Local_Search from a
+  // separate thread unless external synchronization is provided.
+  void set_exchange_check_callback(Exchange_Check_Cbk p_cbk);
 
-  void set_on_infeas_improvement_callback(
-      std::function<void(const double*, size_t, size_t)> p_cbk);
+  // Called before the first feasible solution whenever the current solution
+  // improves the best known number of unsatisfied constraints.
+  void set_on_infeas_improvement_callback(Infeas_Improvement_Cbk p_cbk);
 
+  // Update the best known infeasible progress without changing the current
+  // search point.
+  bool inject_infeas_bound(size_t p_var_num, size_t p_unsat_num);
+
+  // Optionally inject an infeasible current point together with a better unsat
+  // count. If p_sol is nullptr, this is equivalent to inject_infeas_bound().
   bool inject_infeas_solution(const double* p_sol,
                               size_t p_var_num,
                               size_t p_unsat_num);

--- a/src/local_search/Local_Search.h
+++ b/src/local_search/Local_Search.h
@@ -139,6 +139,16 @@ private:
 
   size_t m_min_unsat_con;
 
+  size_t m_exchange_check_interval;
+
+  std::function<void(const double* p_sol, size_t p_var_num, double p_obj)>
+      m_on_improvement_cbk;
+
+  std::function<void()> m_exchange_check_cbk;
+
+  std::function<void(const double* p_sol, size_t p_var_num, size_t p_unsat_num)>
+      m_on_infeas_improvement_cbk;
+
   size_t m_var_num;
 
   size_t m_con_num;
@@ -323,6 +333,28 @@ public:
   void set_tabu_variation(size_t p_value);
 
   void set_break_eq_feas(bool p_break_eq_feas);
+
+  void set_on_improvement_callback(
+      std::function<void(const double*, size_t, double)> p_cbk);
+
+  bool inject_solution(const double* p_sol, size_t p_var_num, double p_obj);
+
+  bool inject_to_current_and_restart(const double* p_sol,
+                                     size_t p_var_num,
+                                     size_t p_restart_step_override);
+
+  void set_exchange_check_interval(size_t p_interval);
+
+  void set_exchange_check_callback(std::function<void()> p_cbk);
+
+  void set_on_infeas_improvement_callback(
+      std::function<void(const double*, size_t, size_t)> p_cbk);
+
+  bool inject_infeas_solution(const double* p_sol,
+                              size_t p_var_num,
+                              size_t p_unsat_num);
+
+  size_t get_min_unsat_con() const;
 };
 
 inline bool Local_Search::con_sat(size_t p_con_idx) const
@@ -391,6 +423,13 @@ inline void Local_Search::update_best_solution()
   m_con_constant[0] = m_best_obj - k_opt_tolerance;
   m_current_obj_breakthrough = false;
   publish_best_obj();
+  if (m_on_improvement_cbk)
+  {
+    double user_obj =
+        m_model_manager->is_min() *
+        (m_best_obj + m_model_manager->obj_offset());
+    m_on_improvement_cbk(m_var_best_value.data(), m_var_num, user_obj);
+  }
 }
 
 inline void Local_Search::publish_best_obj()

--- a/src/model_api/Model_API.cpp
+++ b/src/model_api/Model_API.cpp
@@ -298,9 +298,6 @@ void Model_API::build_model(Model_Manager& p_model_manager)
   for (size_t i = 0; i < m_cons.size(); ++i)
   {
     const auto& con = m_cons[i];
-    if (con.m_var_indices.empty())
-      throw Solver_Error(
-          "Model_API::build_model: empty constraints are not supported");
     std::string con_name = "__api_c" + std::to_string(i);
     bool lb_is_inf = (con.m_lb <= k_neg_inf);
     bool ub_is_inf = (con.m_ub >= k_inf);

--- a/src/model_data/Model_Manager.cpp
+++ b/src/model_data/Model_Manager.cpp
@@ -108,11 +108,21 @@ bool Model_Manager::process_after_read()
   for (size_t con_idx = 1; con_idx < m_con_num; ++con_idx)
   {
     auto& con = m_con_list[con_idx];
-    if (!con.is_inferred_sat() && con.term_num() == 0 &&
-        con.verify_empty_sat())
+    if (!con.is_inferred_sat() && con.term_num() == 0)
     {
-      con.mark_inferred_sat();
-      m_delete_con_num++;
+      if (con.verify_empty_sat())
+      {
+        con.mark_inferred_sat();
+        m_delete_con_num++;
+      }
+      else
+      {
+        printf("c model is infeasible due to empty constraint: %s, "
+               "rhs: %lf\n",
+               con.name().c_str(),
+               con.rhs());
+        return false;
+      }
     }
     classify_con(con);
     if (con.is_inferred_sat())

--- a/tests/api/test_local_mip_api.cpp
+++ b/tests/api/test_local_mip_api.cpp
@@ -467,6 +467,116 @@ bool test_library_parameter_file_errors()
   return ok;
 }
 
+bool test_embedded_exchange_hooks()
+{
+  Local_MIP solver;
+  bool ok = true;
+
+  solver.enable_model_api();
+  solver.set_log_obj(false);
+  solver.set_time_limit(0.05);
+  solver.set_bound_strengthen(false);
+  int x = solver.add_var("x", 0.0, 1.0, 1.0, Var_Type::binary);
+  solver.add_con(1.0, 1.0, std::vector<int>{x}, std::vector<double>{1.0});
+
+  size_t improvement_calls = 0;
+  size_t improvement_n = 0;
+  double improvement_obj = 0.0;
+  solver.set_on_improvement_callback(
+      [&](const double*, size_t n, double obj)
+      {
+        ++improvement_calls;
+        improvement_n = n;
+        improvement_obj = obj;
+      });
+  solver.run();
+  ok &= check(improvement_calls > 0,
+              "improvement callback should run during solve");
+  ok &= check(improvement_n == 1,
+              "improvement callback should report variable count");
+  ok &= check(std::fabs(improvement_obj - solver.get_obj_value()) < 1e-9,
+              "improvement callback should report user objective");
+
+  Local_MIP inject_solver;
+  inject_solver.enable_model_api();
+  int y = inject_solver.add_var("y", 0.0, 10.0, 1.0, Var_Type::real);
+  (void)y;
+  inject_solver.add_con(0.0, 10.0, std::vector<int>{0}, std::vector<double>{1.0});
+  inject_solver.m_model_api->build_model(*inject_solver.m_model_manager);
+  inject_solver.m_model_manager->process_after_read();
+  inject_solver.m_local_search->init_data();
+  inject_solver.m_local_search->m_var_best_value.assign(1, 5.0);
+  inject_solver.m_local_search->m_var_current_value.assign(1, 5.0);
+  inject_solver.m_local_search->m_var_num = 1;
+  inject_solver.m_local_search->m_best_obj = 5.0;
+
+  double better_sol[1] = {2.0};
+  ok &= check(inject_solver.inject_solution(better_sol, 1, 2.0),
+              "inject_solution should accept better external objective");
+  ok &= check(inject_solver.is_feasible(),
+              "inject_solution should mark solver feasible");
+  ok &= check(std::fabs(inject_solver.get_solution()[0] - 2.0) < 1e-9,
+              "inject_solution should copy best solution");
+  ok &= check(!inject_solver.inject_solution(better_sol, 2, 1.0),
+              "inject_solution should reject mismatched variable count");
+  ok &= check(!inject_solver.inject_solution(better_sol, 1, 9.0),
+              "inject_solution should reject worse objective");
+
+  double current_sol[1] = {3.0};
+  ok &= check(inject_solver.inject_to_current_and_restart(current_sol, 1, 77),
+              "inject_to_current_and_restart should accept matching vector");
+  ok &= check(
+      std::fabs(inject_solver.m_local_search->m_var_current_value[0] - 3.0) <
+          1e-9,
+      "inject_to_current_and_restart should copy current solution");
+  ok &= check(inject_solver.m_local_search->m_restart.m_restart_step == 77,
+              "inject_to_current_and_restart should override restart step");
+
+  bool exchange_called = false;
+  inject_solver.set_exchange_check_interval(1);
+  inject_solver.set_exchange_check_callback([&]() { exchange_called = true; });
+  inject_solver.m_local_search->m_exchange_check_cbk();
+  ok &= check(exchange_called,
+              "exchange callback should be stored and callable");
+
+  Local_MIP infeas_solver;
+  infeas_solver.enable_model_api();
+  int z = infeas_solver.add_var("z", 0.0, 1.0, 0.0, Var_Type::binary);
+  (void)z;
+  infeas_solver.add_con(1.0, 1.0, std::vector<int>{0}, std::vector<double>{1.0});
+  infeas_solver.m_model_api->build_model(*infeas_solver.m_model_manager);
+  infeas_solver.m_model_manager->process_after_read();
+  infeas_solver.m_local_search->init_data();
+  infeas_solver.m_local_search->m_var_num = 1;
+  infeas_solver.m_local_search->m_min_unsat_con = 5;
+
+  size_t infeas_calls = 0;
+  size_t infeas_n = 0;
+  size_t infeas_unsat = 0;
+  infeas_solver.set_on_infeas_improvement_callback(
+      [&](const double*, size_t n, size_t unsat)
+      {
+        ++infeas_calls;
+        infeas_n = n;
+        infeas_unsat = unsat;
+      });
+  infeas_solver.m_local_search->m_on_infeas_improvement_cbk(
+      nullptr, 1, 4);
+  ok &= check(infeas_calls == 1 && infeas_n == 1 && infeas_unsat == 4,
+              "infeas improvement callback should be stored and callable");
+
+  ok &= check(infeas_solver.inject_infeas_solution(nullptr, 1, 3),
+              "inject_infeas_solution should accept lower unsat count");
+  ok &= check(infeas_solver.m_local_search->get_min_unsat_con() == 3,
+              "inject_infeas_solution should update min unsat count");
+  ok &= check(!infeas_solver.inject_infeas_solution(nullptr, 1, 3),
+              "inject_infeas_solution should reject non-improving count");
+  ok &= check(!infeas_solver.inject_infeas_solution(nullptr, 2, 2),
+              "inject_infeas_solution should reject mismatched variable count");
+
+  return ok;
+}
+
 } // namespace
 
 int main()
@@ -479,6 +589,7 @@ int main()
   ok &= test_parameter_file_loading();
   ok &= test_library_parameter_file_loading();
   ok &= test_library_parameter_file_errors();
+  ok &= test_embedded_exchange_hooks();
 
   if (!ok)
   {

--- a/tests/api/test_local_mip_api.cpp
+++ b/tests/api/test_local_mip_api.cpp
@@ -482,6 +482,7 @@ bool test_embedded_exchange_hooks()
   size_t improvement_calls = 0;
   size_t improvement_n = 0;
   double improvement_obj = 0.0;
+  size_t exchange_calls = 0;
   solver.set_on_improvement_callback(
       [&](const double*, size_t n, double obj)
       {
@@ -489,9 +490,13 @@ bool test_embedded_exchange_hooks()
         improvement_n = n;
         improvement_obj = obj;
       });
+  solver.set_exchange_check_interval(1);
+  solver.set_exchange_check_callback([&]() { ++exchange_calls; });
   solver.run();
   ok &= check(improvement_calls > 0,
               "improvement callback should run during solve");
+  ok &= check(exchange_calls > 0,
+              "exchange callback should run from the search loop");
   ok &= check(improvement_n == 1,
               "improvement callback should report variable count");
   ok &= check(std::fabs(improvement_obj - solver.get_obj_value()) < 1e-9,
@@ -501,7 +506,7 @@ bool test_embedded_exchange_hooks()
   inject_solver.enable_model_api();
   int y = inject_solver.add_var("y", 0.0, 10.0, 1.0, Var_Type::real);
   (void)y;
-  inject_solver.add_con(0.0, 10.0, std::vector<int>{0}, std::vector<double>{1.0});
+  inject_solver.add_con(0.0, 4.0, std::vector<int>{0}, std::vector<double>{1.0});
   inject_solver.m_model_api->build_model(*inject_solver.m_model_manager);
   inject_solver.m_model_manager->process_after_read();
   inject_solver.m_local_search->init_data();
@@ -519,6 +524,9 @@ bool test_embedded_exchange_hooks()
               "inject_solution should copy best solution");
   ok &= check(!inject_solver.inject_solution(better_sol, 2, 1.0),
               "inject_solution should reject mismatched variable count");
+  double infeasible_sol[1] = {7.0};
+  ok &= check(!inject_solver.inject_solution(infeasible_sol, 1, 1.0),
+              "inject_solution should reject constraint-infeasible solutions");
   ok &= check(!inject_solver.inject_solution(better_sol, 1, 9.0),
               "inject_solution should reject worse objective");
 
@@ -531,16 +539,14 @@ bool test_embedded_exchange_hooks()
       "inject_to_current_and_restart should copy current solution");
   ok &= check(inject_solver.m_local_search->m_restart.m_restart_step == 77,
               "inject_to_current_and_restart should override restart step");
-
-  bool exchange_called = false;
-  inject_solver.set_exchange_check_interval(1);
-  inject_solver.set_exchange_check_callback([&]() { exchange_called = true; });
-  inject_solver.m_local_search->m_exchange_check_cbk();
-  ok &= check(exchange_called,
-              "exchange callback should be stored and callable");
+  double out_of_bounds_sol[1] = {11.0};
+  ok &= check(!inject_solver.inject_to_current_and_restart(
+                  out_of_bounds_sol, 1, 77),
+              "inject_to_current_and_restart should reject invalid values");
 
   Local_MIP infeas_solver;
   infeas_solver.enable_model_api();
+  infeas_solver.set_bound_strengthen(false);
   int z = infeas_solver.add_var("z", 0.0, 1.0, 0.0, Var_Type::binary);
   (void)z;
   infeas_solver.add_con(1.0, 1.0, std::vector<int>{0}, std::vector<double>{1.0});
@@ -565,14 +571,25 @@ bool test_embedded_exchange_hooks()
   ok &= check(infeas_calls == 1 && infeas_n == 1 && infeas_unsat == 4,
               "infeas improvement callback should be stored and callable");
 
-  ok &= check(infeas_solver.inject_infeas_solution(nullptr, 1, 3),
+  double infeas_current[1] = {0.0};
+  ok &= check(infeas_solver.inject_infeas_solution(infeas_current, 1, 3),
               "inject_infeas_solution should accept lower unsat count");
   ok &= check(infeas_solver.m_local_search->get_min_unsat_con() == 3,
               "inject_infeas_solution should update min unsat count");
-  ok &= check(!infeas_solver.inject_infeas_solution(nullptr, 1, 3),
+  ok &= check(
+      std::fabs(infeas_solver.m_local_search->m_var_current_value[0] - 0.0) <
+          1e-9,
+      "inject_infeas_solution should copy current solution when provided");
+  ok &= check(infeas_solver.inject_infeas_bound(1, 2),
+              "inject_infeas_bound should accept lower unsat count");
+  ok &= check(infeas_solver.m_local_search->get_min_unsat_con() == 2,
+              "inject_infeas_bound should update min unsat count");
+  ok &= check(!infeas_solver.inject_infeas_solution(nullptr, 1, 2),
               "inject_infeas_solution should reject non-improving count");
-  ok &= check(!infeas_solver.inject_infeas_solution(nullptr, 2, 2),
+  ok &= check(!infeas_solver.inject_infeas_solution(nullptr, 2, 1),
               "inject_infeas_solution should reject mismatched variable count");
+  ok &= check(!infeas_solver.inject_infeas_solution(out_of_bounds_sol, 1, 1),
+              "inject_infeas_solution should reject invalid values");
 
   return ok;
 }
@@ -589,6 +606,15 @@ bool test_model_api_empty_constraints()
   sat_solver.m_model_api->build_model(*sat_solver.m_model_manager);
   ok &= check(sat_solver.m_model_manager->process_after_read(),
               "satisfied empty constraints should be accepted");
+
+  Local_MIP infeas_solver;
+  infeas_solver.enable_model_api();
+  infeas_solver.set_bound_strengthen(false);
+  infeas_solver.add_var("x", 0.0, 1.0, 0.0, Var_Type::binary);
+  infeas_solver.add_con(1.0, k_inf, std::vector<int>{}, std::vector<double>{});
+  infeas_solver.m_model_api->build_model(*infeas_solver.m_model_manager);
+  ok &= check(!infeas_solver.m_model_manager->process_after_read(),
+              "unsatisfied empty constraints should make the model infeasible");
 
   return ok;
 }

--- a/tests/api/test_local_mip_api.cpp
+++ b/tests/api/test_local_mip_api.cpp
@@ -577,6 +577,22 @@ bool test_embedded_exchange_hooks()
   return ok;
 }
 
+bool test_model_api_empty_constraints()
+{
+  bool ok = true;
+
+  Local_MIP sat_solver;
+  sat_solver.enable_model_api();
+  sat_solver.set_bound_strengthen(false);
+  sat_solver.add_var("x", 0.0, 1.0, 0.0, Var_Type::binary);
+  sat_solver.add_con(-1.0, 2.0, std::vector<int>{}, std::vector<double>{});
+  sat_solver.m_model_api->build_model(*sat_solver.m_model_manager);
+  ok &= check(sat_solver.m_model_manager->process_after_read(),
+              "satisfied empty constraints should be accepted");
+
+  return ok;
+}
+
 } // namespace
 
 int main()
@@ -590,6 +606,7 @@ int main()
   ok &= test_library_parameter_file_loading();
   ok &= test_library_parameter_file_errors();
   ok &= test_embedded_exchange_hooks();
+  ok &= test_model_api_empty_constraints();
 
   if (!ok)
   {


### PR DESCRIPTION
This PR prepares Local-MIP for embedded/library use while preserving the default standalone CLI behavior.

It adds CMake options to optionally disable CLI/tests when consumed as a subproject, exposes a `LocalMIP::core` target, and introduces solution-exchange hooks for embedders: feasible incumbent callbacks, periodic exchange callbacks, feasible/current-solution injection, and infeasible-progress exchange. The new APIs are disabled by default and only affect users that explicitly register callbacks or inject solutions. The PR also aligns Model API behavior with the file-reader path by accepting semantically valid empty constraints and explicitly detecting unsatisfied empty constraints as infeasible.

API tests were extended to cover exchange callbacks, solution injection validation, infeasible progress injection, and empty-constraint handling. Local-MIP `ctest` passes 12/12.